### PR TITLE
Fixing retain cycle

### DIFF
--- a/UIAlertController+Blocks.m
+++ b/UIAlertController+Blocks.m
@@ -43,9 +43,16 @@ NSInteger const UIAlertControllerBlocksFirstOtherButtonIndex = 2;
                    otherButtonTitles:(NSArray *)otherButtonTitles
                             tapBlock:(UIAlertControllerCompletionBlock)tapBlock
 {
-    UIAlertController *controller = [self alertControllerWithTitle:title
-                                                           message:message
-                                                    preferredStyle:preferredStyle];
+#if __has_feature(objc_arc)
+    __weak UIAlertController *controller = [self alertControllerWithTitle:title
+                                                                  message:message
+                                                           preferredStyle:preferredStyle];
+    
+#else
+    __block UIAlertController *controller = [self alertControllerWithTitle:title
+                                                                  message:message
+                                                           preferredStyle:preferredStyle];
+#endif
     
     if (cancelButtonTitle) {
         UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:cancelButtonTitle


### PR DESCRIPTION
UIAlertController *controller used inside another block and this is create retain cycle. We should mark it as __block (or __weak in ARC) to exclude this retain cycle.
